### PR TITLE
replace collections with switch case

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -175,6 +175,6 @@ class Json
         $collections = self::jsonLastErrorCollections();
         $jsonLastError = json_last_error();
 
-        return array_key_exists($jsonLastError, $collections) ? $collections[$jsonLastError] : $collections['default'];
+        return isset($jsonLastError) ? $collections[$jsonLastError] : $collections['default'];
     }
 }

--- a/src/Json.php
+++ b/src/Json.php
@@ -11,6 +11,7 @@
 namespace Josantonius\Json;
 
 use Josantonius\Json\Exception\JsonException;
+use Josantonius\Json\Exception\JsonLastErrorException;
 
 /**
  * Json handler.
@@ -105,6 +106,64 @@ class Json
     }
 
     /**
+     * The JSON last error collections.
+     *
+     * @since 1.1.3
+     *
+     * @return array
+     */
+    private static function jsonLastErrorCollections()
+    {
+        return [
+            JSON_ERROR_NONE => null,
+            JSON_ERROR_DEPTH => [
+                'message' => 'Maximum stack depth exceeded',
+                'error-code' => 1,
+            ],
+            JSON_ERROR_STATE_MISMATCH => [
+                'message' => 'Underflow or the modes mismatch',
+                'error-code' => 2,
+            ],
+            JSON_ERROR_CTRL_CHAR => [
+                'message' => 'Unexpected control char found',
+                'error-code' => 3,
+            ],
+            JSON_ERROR_SYNTAX => [
+                'message' => 'Syntax error, malformed JSON',
+                'error-code' => 4,
+            ],
+            JSON_ERROR_UTF8 => [
+                'message' => 'Malformed UTF-8 characters',
+                'error-code' => 5,
+            ],
+            JSON_ERROR_RECURSION => [
+                'message' => 'Recursion error in value to be encoded',
+                'error-code' => 6,
+            ],
+            JSON_ERROR_INF_OR_NAN => [
+                'message' => 'Error NAN/INF in value to be encoded',
+                'error-code' => 7,
+            ],
+            JSON_ERROR_UNSUPPORTED_TYPE => [
+                'message' => 'Type value given cannot be encoded',
+                'error-code' => 8,
+            ],
+            JSON_ERROR_INVALID_PROPERTY_NAME => [
+                'message' => 'Name value given cannot be encoded',
+                'error-code' => 9,
+            ],
+            JSON_ERROR_UTF16 => [
+                'message' => 'Malformed UTF-16 characters',
+                'error-code' => 10,
+            ],
+            'default' => [
+                'message' => 'Unknown error',
+                'error-code' => 999,
+            ],
+        ];
+    }
+
+    /**
      * Check for errors.
      *
      * @since 1.1.3
@@ -113,64 +172,9 @@ class Json
      */
     private static function jsonLastError()
     {
-        switch (json_last_error()) {
-            case JSON_ERROR_NONE:
-                return null;
-            case JSON_ERROR_DEPTH:
-                return [
-                    'message' => 'Maximum stack depth exceeded',
-                    'error-code' => 1,
-                ];
-            case JSON_ERROR_STATE_MISMATCH:
-                return [
-                    'message' => 'Underflow or the modes mismatch',
-                    'error-code' => 2,
-                ];
-            case JSON_ERROR_CTRL_CHAR:
-                return [
-                    'message' => 'Unexpected control char found',
-                    'error-code' => 3,
-                ];
-            case JSON_ERROR_SYNTAX:
-                return [
-                    'message' => 'Syntax error, malformed JSON',
-                    'error-code' => 4,
-                ];
-            case JSON_ERROR_UTF8:
-                return [
-                    'message' => 'Malformed UTF-8 characters',
-                    'error-code' => 5,
-                ];
-            case JSON_ERROR_RECURSION:
-                return [
-                    'message' => 'Recursion error in value to be encoded',
-                    'error-code' => 6,
-                ];
-            case JSON_ERROR_INF_OR_NAN:
-                return [
-                    'message' => 'Error NAN/INF in value to be encoded',
-                    'error-code' => 7,
-                ];
-            case JSON_ERROR_UNSUPPORTED_TYPE:
-                return [
-                    'message' => 'Type value given cannot be encoded',
-                    'error-code' => 8,
-                ];
-            case 9: // JSON_ERROR_INVALID_PROPERTY_NAME (PHP 7.0.0)
-                return [
-                    'message' => 'Name value given cannot be encoded',
-                    'error-code' => 9,
-                ];
-            case 10: //JSON_ERROR_UTF16 (PHP 7.0.0)
-                return [
-                    'message' => 'Malformed UTF-16 characters',
-                    'error-code' => 10,
-                ];
-            default:
-                return [
-                    'message' => 'Unknown error',
-                    'error-code' => 999,
-                ];
-        }
+        $collections = self::jsonLastErrorCollections();
+        $jsonLastError = json_last_error();
+
+        return array_key_exists($jsonLastError, $collections) ? $collections[$jsonLastError] : $collections['default'];
     }
 }

--- a/src/Json.php
+++ b/src/Json.php
@@ -114,7 +114,7 @@ class Json
      */
     private static function jsonLastErrorCollections()
     {
-        return [
+        $collections = [
             JSON_ERROR_NONE => null,
             JSON_ERROR_DEPTH => [
                 'message' => 'Maximum stack depth exceeded',
@@ -148,19 +148,25 @@ class Json
                 'message' => 'Type value given cannot be encoded',
                 'error-code' => 8,
             ],
-            JSON_ERROR_INVALID_PROPERTY_NAME => [
-                'message' => 'Name value given cannot be encoded',
-                'error-code' => 9,
-            ],
-            JSON_ERROR_UTF16 => [
-                'message' => 'Malformed UTF-16 characters',
-                'error-code' => 10,
-            ],
             'default' => [
                 'message' => 'Unknown error',
                 'error-code' => 999,
             ],
         ];
+
+        if (version_compare(PHP_VERSION, '7.0.0', '>='))
+        {
+            $collections[JSON_ERROR_INVALID_PROPERTY_NAME] = [
+                'message' => 'Name value given cannot be encoded',
+                'error-code' => 9,
+            ];
+            $collections[JSON_ERROR_UTF16] = [
+                'message' => 'Malformed UTF-16 characters',
+                'error-code' => 10,
+            ];
+        }
+
+        return $collections;
     }
 
     /**


### PR DESCRIPTION
Firstly, thank you for your PHP-Json to access JSON easily.
Here is the changed log:

# Changed log
- I think the ```switch...case``` is very long and not readable. And I let the ```jsonLastErrorCollections``` method being the collection associate array. I think it's more flexible, convenient and readable.

One more thing I mention that the ```json_last_error``` will print the unexpected error.
Excluding the ```JSON_ERROR_NONE```, the all error message should throw the Exceptions.
What do you think?

Thanks.